### PR TITLE
Add support for V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0]
+
+Add support for Vipps Login V2. Add the scope `VippsScopes.ApiV2` to your Vipps OpenId configuration to switch to the new api.
+
 ## [0.1.0-alpha]
 
-First release
+First release. This version passed security pentests.

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="episerver" value="http://nuget.episerver.com/feed/packages.svc" />
+  </packageSources>
+</configuration>

--- a/docs/configure-episerver.md
+++ b/docs/configure-episerver.md
@@ -70,6 +70,7 @@ public class Startup
             // 1. Here you pass in the scopes you need
             Scope = string.Join(" ", new []
             {
+                VippsScopes.ApiV2,
                 VippsScopes.OpenId,
                 VippsScopes.Email,
                 VippsScopes.Name,
@@ -81,7 +82,9 @@ public class Startup
             // By default it will handle:
             // RedirectToIdentityProvider - Redirecting to Vipps using correct RedirectUri
             // AuthorizationCodeReceived - Exchange Authentication code for id_token and access_token
-            // DefaultSecurityTokenValidated - Find matching CustomerContact
+            // SecurityTokenValidated - Used to populate ClaimsIdentity and sync to db
+            //      Override this to implement your own logic for finding and creating accounts.
+            //      See VippsEpiNotifications.DefaultSecurityTokenValidated for an example
             Notifications = new VippsEpiNotifications
             {
                 AuthenticationFailed = context =>
@@ -127,7 +130,6 @@ public class Startup
             bool.TryParse(ctx.Request.Query.Get("LinkAccount"), out var linkAccount);
             if (linkAccount && VippsLoginCommerceService.Service.HandleLinkAccount(ctx)) return Task.Delay(0);
 
-            // Return to this url after authenticating
             // Return to this url after authenticating
             var returnUrl = ctx.Request.Query.Get("ReturnUrl");
             if (string.IsNullOrWhiteSpace(returnUrl))

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.csproj
@@ -99,6 +99,9 @@
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
+    <Reference Include="IdentityModel, Version=4.1.0.0, Culture=neutral, PublicKeyToken=e7877f4675df049f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IdentityModel.4.1.0\lib\net472\IdentityModel.dll</HintPath>
+    </Reference>
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
     </Reference>
@@ -184,6 +187,9 @@
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ComponentModel.Annotations.4.4.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
     </Reference>
@@ -199,8 +205,18 @@
     <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.3.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
@@ -215,6 +231,9 @@
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.Principal.Windows.4.4.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encodings.Web.4.7.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.AccessControl, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.AccessControl.4.4.0\lib\net461\System.Threading.AccessControl.dll</HintPath>

--- a/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.nuspec
+++ b/src/Vipps.Login.Episerver.Commerce/Vipps.Login.Episerver.Commerce.nuspec
@@ -6,6 +6,7 @@
     <authors>Vipps AS</authors>
     <owners>Vipps AS</owners>
     <projectUrl>https://github.com/vippsas/vipps-login-dotnet</projectUrl>
+    <repository type="git" url="https://github.com/vippsas/vipps-login-dotnet" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Vipps Login for Episerver</description>
     <tags>Geta Vipps Login Episerver</tags>

--- a/src/Vipps.Login.Episerver.Commerce/packages.config
+++ b/src/Vipps.Login.Episerver.Commerce/packages.config
@@ -8,6 +8,7 @@
   <package id="EPiServer.Commerce.Core" version="12.17.1" targetFramework="net472" />
   <package id="EPiServer.Framework" version="11.14.2" targetFramework="net472" />
   <package id="EPiServer.Framework.AspNet" version="11.14.2" targetFramework="net472" />
+  <package id="IdentityModel" version="4.1.0" targetFramework="net472" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net472" />
@@ -25,14 +26,19 @@
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net472" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net472" />
   <package id="System.ComponentModel.Annotations" version="4.4.0" targetFramework="net472" />
   <package id="System.Data.SqlClient" version="4.4.0" targetFramework="net472" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.3.0" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.3" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
   <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net472" />
   <package id="System.Security.AccessControl" version="4.4.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Xml" version="4.4.2" targetFramework="net472" />
   <package id="System.Security.Permissions" version="4.4.0" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.7.0" targetFramework="net472" />
   <package id="System.Threading.AccessControl" version="4.4.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/src/Vipps.Login.Episerver/Vipps.Login.Episerver.nuspec
+++ b/src/Vipps.Login.Episerver/Vipps.Login.Episerver.nuspec
@@ -6,6 +6,7 @@
     <authors>Vipps AS</authors>
     <owners>Vipps AS</owners>
     <projectUrl>https://github.com/vippsas/vipps-login-dotnet</projectUrl>
+    <repository type="git" url="https://github.com/vippsas/vipps-login-dotnet" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Vipps Login for Episerver</description>
     <tags>Geta Vipps Login Episerver</tags>

--- a/src/Vipps.Login/IVippsLoginService.cs
+++ b/src/Vipps.Login/IVippsLoginService.cs
@@ -1,5 +1,7 @@
-﻿using System.Security.Claims;
+﻿using System.Collections.Generic;
+using System.Security.Claims;
 using System.Security.Principal;
+using System.Threading.Tasks;
 using Vipps.Login.Models;
 
 namespace Vipps.Login
@@ -10,5 +12,6 @@ namespace Vipps.Login
         bool IsVippsIdentity(ClaimsIdentity identity);
         VippsUserInfo GetVippsUserInfo(IIdentity identity);
         VippsUserInfo GetVippsUserInfo(ClaimsIdentity identity);
+        Task<IEnumerable<Claim>> GetUserInfoClaims(string userInfoEndpoint, string accessToken);
     }
 }

--- a/src/Vipps.Login/Models/VippsAddress.cs
+++ b/src/Vipps.Login/Models/VippsAddress.cs
@@ -15,5 +15,6 @@ namespace Vipps.Login.Models
         [JsonProperty("address_type")]
         [JsonConverter(typeof(StringEnumConverter))]
         public VippsAddressType AddressType { get; set; }
+        public bool IsPreferred { get; set; }
     }
 }

--- a/src/Vipps.Login/Vipps.Login.nuspec
+++ b/src/Vipps.Login/Vipps.Login.nuspec
@@ -6,6 +6,7 @@
     <authors>Vipps AS</authors>
     <owners>Vipps AS</owners>
     <projectUrl>https://github.com/vippsas/vipps-login-dotnet</projectUrl>
+    <repository type="git" url="https://github.com/vippsas/vipps-login-dotnet" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Vipps Login using Microsoft.Owin OpenIdConnect</description>
     <tags>Geta Vipps Login Owin OpenIdConnect</tags>

--- a/src/Vipps.Login/VippsClaimTypes.cs
+++ b/src/Vipps.Login/VippsClaimTypes.cs
@@ -3,5 +3,6 @@
     public static class VippsClaimTypes
     {
         public const string Nnin = "nin";
+        public const string OtherAddresses = "other_addresses";
     }
 }

--- a/src/Vipps.Login/VippsClaimTypes.cs
+++ b/src/Vipps.Login/VippsClaimTypes.cs
@@ -2,6 +2,6 @@
 {
     public static class VippsClaimTypes
     {
-        public const string Nnin = "nnin";
+        public const string Nnin = "nin";
     }
 }

--- a/src/Vipps.Login/VippsLoginService.cs
+++ b/src/Vipps.Login/VippsLoginService.cs
@@ -88,7 +88,12 @@ namespace Vipps.Login
         {
             return identity
                 .FindAll(JwtClaimTypes.Address)
-                .Select(DeserializeAddress);
+                .Select(x => DeserializeAddress(x, true))
+                .Union(
+                    identity
+                    .FindAll(VippsClaimTypes.OtherAddresses)
+                    .Select(x => DeserializeAddress(x)))
+                .ToList();
         }
 
         protected virtual IEnumerable<string> GetValidIssuers()
@@ -101,14 +106,16 @@ namespace Vipps.Login
             }
         }
 
-        protected virtual VippsAddress DeserializeAddress(Claim claim)
+        protected virtual VippsAddress DeserializeAddress(Claim claim, bool isPreferred = false)
         {
             if (string.IsNullOrWhiteSpace(claim?.Value))
             {
                 return null;
             }
 
-            return JsonConvert.DeserializeObject<VippsAddress>(claim.Value);
+            var address = JsonConvert.DeserializeObject<VippsAddress>(claim.Value);
+            address.IsPreferred = isPreferred;
+            return address;
         }
 
         protected virtual string ParseString(Claim stringClaim)

--- a/src/Vipps.Login/VippsScopes.cs
+++ b/src/Vipps.Login/VippsScopes.cs
@@ -2,6 +2,7 @@
 {
     public static class VippsScopes
     {
+        public const string ApiV2 = "api_version_2";
         public const string OpenId = "openid";
         public const string Name = "name";
         public const string Email = "email";

--- a/src/Vipps.Login/VippsScopes.cs
+++ b/src/Vipps.Login/VippsScopes.cs
@@ -8,6 +8,6 @@
         public const string Address = "address";
         public const string PhoneNumber = "phoneNumber";
         public const string BirthDate = "birthDate";
-        public const string Nnin = "nnin";
+        public const string Nnin = "nin";
     }
 }

--- a/test/Vipps.Login.Episerver.Commerce.Tests/Vipps.Login.Episerver.Commerce.Tests.csproj
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/Vipps.Login.Episerver.Commerce.Tests.csproj
@@ -106,6 +106,9 @@
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
     </Reference>
+    <Reference Include="IdentityModel, Version=4.1.0.0, Culture=neutral, PublicKeyToken=e7877f4675df049f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IdentityModel.4.1.0\lib\net472\IdentityModel.dll</HintPath>
+    </Reference>
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
     </Reference>
@@ -191,6 +194,9 @@
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ComponentModel.Annotations.4.4.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
     </Reference>
@@ -206,8 +212,18 @@
     <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IdentityModel.Tokens.Jwt.5.3.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
@@ -222,6 +238,9 @@
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Security.Principal.Windows.4.4.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encodings.Web.4.7.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.AccessControl, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.AccessControl.4.4.0\lib\net461\System.Threading.AccessControl.dll</HintPath>

--- a/test/Vipps.Login.Episerver.Commerce.Tests/packages.config
+++ b/test/Vipps.Login.Episerver.Commerce.Tests/packages.config
@@ -9,6 +9,7 @@
   <package id="EPiServer.Framework" version="11.14.2" targetFramework="net472" />
   <package id="EPiServer.Framework.AspNet" version="11.14.2" targetFramework="net472" />
   <package id="FakeItEasy" version="5.5.0" targetFramework="net472" />
+  <package id="IdentityModel" version="4.1.0" targetFramework="net472" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net472" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net472" />
@@ -26,14 +27,19 @@
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net472" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net472" />
   <package id="System.ComponentModel.Annotations" version="4.4.0" targetFramework="net472" />
   <package id="System.Data.SqlClient" version="4.4.0" targetFramework="net472" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.3.0" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.3" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
   <package id="System.Reflection.Emit" version="4.3.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net472" />
   <package id="System.Security.AccessControl" version="4.4.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Xml" version="4.4.2" targetFramework="net472" />
   <package id="System.Security.Permissions" version="4.4.0" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.7.0" targetFramework="net472" />
   <package id="System.Threading.AccessControl" version="4.4.0" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net472" />

--- a/test/Vipps.Login.Tests/VippsLoginServiceTests.cs
+++ b/test/Vipps.Login.Tests/VippsLoginServiceTests.cs
@@ -84,11 +84,44 @@ namespace Vipps.Login.Tests
         }
 
         [Fact]
-        public void ParsesNorwegianDate()
+        public void ParsesBirthDate()
         {
             var service = new VippsLoginService();
             var identity = CreateIdentity();
             identity.AddClaim(_birthDateClaim);
+
+            var userInfo = service.GetVippsUserInfo(identity);
+            Assert.Equal(new DateTime(2020, 1, 2), userInfo.BirthDate);
+        }
+
+        [Fact]
+        public void ParsesBirthDate2()
+        {
+            var service = new VippsLoginService();
+            var identity = CreateIdentity();
+            identity.AddClaim(_birthDateClaim2);
+
+            var userInfo = service.GetVippsUserInfo(identity);
+            Assert.Equal(new DateTime(2020, 6,30), userInfo.BirthDate);
+        }
+
+        [Fact]
+        public void ParsesNorwegianBirthDate()
+        {
+            var service = new VippsLoginService();
+            var identity = CreateIdentity();
+            identity.AddClaim(_birthDateClaimNo);
+
+            var userInfo = service.GetVippsUserInfo(identity);
+            Assert.Equal(new DateTime(2020, 1, 2), userInfo.BirthDate);
+        }
+
+        [Fact]
+        public void ParsesNorwegianBirthDate2()
+        {
+            var service = new VippsLoginService();
+            var identity = CreateIdentity();
+            identity.AddClaim(_birthDateClaimNo2);
 
             var userInfo = service.GetVippsUserInfo(identity);
             Assert.Equal(new DateTime(2020, 6, 30), userInfo.BirthDate);
@@ -142,7 +175,6 @@ namespace Vipps.Login.Tests
                 _issuerClaim,
                 _subClaim,
                 _emailClaim,
-                _birthDateClaim,
                 _familyNameClaim,
                 _givenNameClaim,
                 _nameClaim,
@@ -154,7 +186,10 @@ namespace Vipps.Login.Tests
 
         private readonly Claim _issuerClaim = CreateClaim(JwtClaimTypes.Issuer, VippsLoginService.VippsTestApi);
         private readonly Claim _subClaim = CreateClaim(ClaimTypes.NameIdentifier, "3086A8D1-0AE2-4028-B5A8-D41628DDC9E8");
-        private readonly Claim _birthDateClaim = CreateClaim(ClaimTypes.DateOfBirth, "30.6.2020");
+        private readonly Claim _birthDateClaim = CreateClaim(ClaimTypes.DateOfBirth, "2020-01-02");
+        private readonly Claim _birthDateClaim2 = CreateClaim(ClaimTypes.DateOfBirth, "2020-06-30");
+        private readonly Claim _birthDateClaimNo = CreateClaim(ClaimTypes.DateOfBirth, "2.1.2020");
+        private readonly Claim _birthDateClaimNo2 = CreateClaim(ClaimTypes.DateOfBirth, "30.6.2020");
         private readonly Claim _emailClaim = CreateClaim(ClaimTypes.Email);
         private readonly Claim _familyNameClaim = CreateClaim(ClaimTypes.Surname);
         private readonly Claim _givenNameClaim = CreateClaim(ClaimTypes.GivenName);

--- a/test/Vipps.Login.Tests/VippsLoginServiceTests.cs
+++ b/test/Vipps.Login.Tests/VippsLoginServiceTests.cs
@@ -78,9 +78,21 @@ namespace Vipps.Login.Tests
             identity.AddClaims(new[] {_address1, _address2, _address3});
             var userInfo = service.GetVippsUserInfo(identity);
             Assert.Equal(3, userInfo.Addresses.Count());
-            Assert.Equal(1, userInfo.Addresses.Count(x=>x.AddressType.Equals(VippsAddressType.Home)));
+            Assert.Equal(1, userInfo.Addresses.Count(x => x.AddressType.Equals(VippsAddressType.Home)));
             Assert.Equal(1, userInfo.Addresses.Count(x => x.AddressType.Equals(VippsAddressType.Work)));
             Assert.Equal(1, userInfo.Addresses.Count(x => x.AddressType.Equals(VippsAddressType.Other)));
+        }
+
+        [Fact]
+        public void HasPreferredAddress()
+        {
+            var service = new VippsLoginService();
+            var identity = CreateIdentity();
+            identity.AddClaims(new[] { _address1, _address2, _address3 });
+            var userInfo = service.GetVippsUserInfo(identity);
+            Assert.Equal(3, userInfo.Addresses.Count());
+            Assert.Equal(1, userInfo.Addresses.Count(x => x.IsPreferred));
+            Assert.Equal("Rådhusgata 28\nBar 3", userInfo.Addresses.First(x => x.IsPreferred).StreetAddress);
         }
 
         [Fact]
@@ -209,8 +221,8 @@ namespace Vipps.Login.Tests
             return new Claim(claimType, claimValue ?? claimType);
         }
 
-        private readonly Claim _address1 = new Claim(JwtClaimTypes.Address, "{\"address_type\": \"home\",\"country\": \"NO\",\"formatted\": \"BOKS 6300, ETTERSTAD\n0603\nOSLO\nNO\",\"postal_code\": \"0603\",\"region\": \"OSLO\",\"street_address\": \"BOKS 6300, ETTERSTAD\"}");
-        private readonly Claim _address2 = new Claim(JwtClaimTypes.Address, "{\"address_type\": \"work\",\"country\": \"NO\",\"formatted\": \"Skippergata 4\n0152\nOslo\nNO\",\"postal_code\": \"0152\",\"region\": \"Oslo\",\"street_address\": \"Skippergata 4\"}");
+        private readonly Claim _address1 = new Claim(VippsClaimTypes.OtherAddresses, "{\"address_type\": \"home\",\"country\": \"NO\",\"formatted\": \"BOKS 6300, ETTERSTAD\n0603\nOSLO\nNO\",\"postal_code\": \"0603\",\"region\": \"OSLO\",\"street_address\": \"BOKS 6300, ETTERSTAD\"}");
+        private readonly Claim _address2 = new Claim(VippsClaimTypes.OtherAddresses, "{\"address_type\": \"work\",\"country\": \"NO\",\"formatted\": \"Skippergata 4\n0152\nOslo\nNO\",\"postal_code\": \"0152\",\"region\": \"Oslo\",\"street_address\": \"Skippergata 4\"}");
         private readonly Claim _address3 = new Claim(JwtClaimTypes.Address, "{\"address_type\":\"other\",\"country\":\"NO\",\"formatted\":\"Rådhusgata 28\nBar 3\n0151\nOslo\nNO\",\"postal_code\":\"0151\",\"region\":\"Oslo\",\"street_address\":\"Rådhusgata 28\nBar 3\"}");
     }
 }


### PR DESCRIPTION
In V2 the id_token only contains user_ids, therefore the library now retrieves claims from UserInfo endpoint for V2.
Add support for parsing new other_address claims and add property for the preferred address.

Upgrading is easy, just add `VippsScopes.ApiV2` to the scopes your configuration (see documentation).
https://github.com/vippsas/vipps-login-api/blob/master/vipps-login-migrate-api-1.0-to-2.0.md
